### PR TITLE
Added CSP middleware

### DIFF
--- a/yesod-csp.cabal
+++ b/yesod-csp.cabal
@@ -32,6 +32,8 @@ library
                        , attoparsec
                        , template-haskell
                        , syb
+                       , wai
+                       , case-insensitive
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
Use a WAI middleware to add CSP headers to all responses directly, even those that don't go via `defaultLayout`. If you always want the CSP headers, this is less error prone than adding them manually to handlers.